### PR TITLE
Memcpy timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Usage
     $ ./libcxl_tests        # Test libcxl
     $ ./memcpy_afu_ctx      # Test memcpy AFU memory copy
     $ ./memcpy_afu_ctx -t   # Test memcpy AFU timebase sync
-    
+
     Usage: memcpy_afu_ctx [options]
     Options:
         -c <card_num>   Use this CAPI card (default 0).
@@ -56,6 +56,8 @@ Usage
         -p <procs>      Fork this number of processes (default 1).
         -s <bufsize>    Copy this number of bytes (default 1024).
         -t              Do not memcpy. Test timebase sync instead.
+        -e              End timeout.
+                        Seconds to wait for the AFU to signal completion.
 
 Contributing
 ------------

--- a/memcpy_afu_ctx.c
+++ b/memcpy_afu_ctx.c
@@ -47,9 +47,8 @@
 #define ERR_MEMCMP	0x4
 
 /* Default amount of time to wait (in seconds) for a test to complete */
-#define TIMEOUT		120
 #define KILL_TIMEOUT	5
-#define COMPLETION_TIMEOUT     TIMEOUT
+#define COMPLETION_TIMEOUT     120
 
 static void get_name(char **name, int processes, int loops)
 {

--- a/memcpy_afu_ctx.c
+++ b/memcpy_afu_ctx.c
@@ -362,8 +362,7 @@ int test_afu_memcpy(char *src, char *dst, size_t size, int count,
 				break;
 			}
 
-			if (queued_we->status & MEMCPY_WE_STAT_COMPLETE) {
-				/* Success */
+			if (queued_we->status) {
 				break;
 			}
 		}


### PR DESCRIPTION
Allow the user to specify a timeout to wait for a memcpy task to complete via a new '-e' switch.

Also marked up the readme with markdown so that it renders correctly in Github.