### PR TITLE
Alignment related fixes for cxl-threads test suite.

### DIFF
--- a/cxl-threads.c
+++ b/cxl-threads.c
@@ -64,7 +64,7 @@
 /* default Master context to be used */
 #define MEMCPY_MASTER_CONTEXT "/dev/cxl/afu0.0m"
 
-#define MAX_BUFFER_SIZE  2048
+#define MAX_BUFFER_SIZE  1024
 
 /* holds the path to  slave context to be used */
 char arg_master_context[PATH_MAX] = MEMCPY_MASTER_CONTEXT;
@@ -223,9 +223,10 @@ void *afu_slave_threadproc_static(void *arg)
 {
 	int thindex, index;
 	uintptr_t rc = 0;
-	char srcbuffer[MAX_BUFFER_SIZE], dstbuffer[MAX_BUFFER_SIZE];
 	int fd_random;
 	int loops = (uintptr_t)arg;
+	char srcbuffer[MAX_BUFFER_SIZE] __attribute__((aligned (128)));
+	char dstbuffer[MAX_BUFFER_SIZE] __attribute__((aligned (128)));
 
 	/* get the task_struct pid */
 	thindex = syscall(SYS_gettid);

--- a/cxl-threads.c
+++ b/cxl-threads.c
@@ -157,8 +157,8 @@ void *afu_slave_threadproc_dynamic(void *arg)
 	for (index = 0; index < loops; ++index) {
 		int ret;
 
-		srcbuffer = aligned_alloc(64, szbuffer);
-		dstbuffer = aligned_alloc(64, szbuffer);
+		srcbuffer = aligned_alloc(128, szbuffer);
+		dstbuffer = aligned_alloc(128, szbuffer);
 
 		if ((srcbuffer == NULL) || (dstbuffer == NULL)) {
 		  printf("THREAD[%d]: Copy Loop index %d .. "


### PR DESCRIPTION
This pull request fixes 2 alignment related issues for source/destination buffers for memcopy cxl-threads tests. Memcopy 2.0 AFU needs these buffers to be 128 bytes aligned which was not the case with current implementation and hence the test was failing.